### PR TITLE
Fix when using scriptPath

### DIFF
--- a/ti.dynamiclib.js
+++ b/ti.dynamiclib.js
@@ -41,7 +41,7 @@ exports.init = function (logger, config, cli, appc) {
 				};
 			}
 			addLibrary(builder, cli, xobjs, frameworkPaths);
-			addScriptBuildPhase(scriptPath);
+			addScriptBuildPhase(builder, xobjs, scriptPath);
 		}
 	});
 };
@@ -75,7 +75,7 @@ function addLibrary(builder, cli, xobjs, frameworkPaths) {
 	});
 }
 
-function addScriptBuildPhase(scriptPath) {
+function addScriptBuildPhase(builder, xobjs, scriptPath) {
 	if (!scriptPath) return;
 	
 	var script_uuid = builder.generateXcodeUuid();


### PR DESCRIPTION
Fixes the following issue:

```
hooks/ti.dynamiclib.js:86
	createPBXRunShellScriptBuildPhase(xobjs, script_uuid, shell_path, shell_script);
                                   ^
ReferenceError: xobjs is not defined
```
